### PR TITLE
Update to latest version of slog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/neilotoole/slogt
 
 go 1.20
 
-require golang.org/x/exp v0.0.0-20230321023759-10a507213a29
+require golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
+golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/slogt.go
+++ b/slogt.go
@@ -32,7 +32,7 @@ func Text() Option {
 			Level:     slog.LevelDebug,
 		}
 		// The opts may have already set the handler.
-		b.Handler = hOpts.NewTextHandler(b.buf)
+		b.Handler = slog.NewTextHandler(b.buf, &hOpts)
 	}
 }
 
@@ -46,7 +46,7 @@ func JSON() Option {
 			Level:     slog.LevelDebug,
 		}
 		// The opts may have already set the handler.
-		b.Handler = hOpts.NewJSONHandler(b.buf)
+		b.Handler = slog.NewJSONHandler(b.buf, &hOpts)
 	}
 }
 

--- a/slogt_test.go
+++ b/slogt_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 func TestSlog_Ugly(t *testing.T) {
-	log := slog.New(slog.NewTextHandler(os.Stdout))
+	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	t.Log("I am indented correctly")
 	log.Info("But I am not")
 }
@@ -37,7 +37,7 @@ func TestSlog_Ugly_Parallel(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
-			handler := slog.NewTextHandler(os.Stdout)
+			handler := slog.NewTextHandler(os.Stdout, nil)
 			log := slog.New(handler)
 
 			for j := 0; j < iter; j++ {
@@ -95,9 +95,9 @@ func TestJSON(t *testing.T) {
 func TestFactory(t *testing.T) {
 	// This factory returns a slog.Handler using slog.LevelError.
 	f := slogt.Factory(func(w io.Writer) slog.Handler {
-		return slog.HandlerOptions{
+		return slog.NewTextHandler(w, &slog.HandlerOptions{
 			Level: slog.LevelError,
-		}.NewTextHandler(w)
+		})
 	})
 
 	log := slogt.New(t, f)
@@ -107,9 +107,9 @@ func TestFactory(t *testing.T) {
 
 func TestCaller(t *testing.T) {
 	f := slogt.Factory(func(w io.Writer) slog.Handler {
-		return slog.HandlerOptions{
+		return slog.NewTextHandler(w, &slog.HandlerOptions{
 			AddSource: true,
-		}.NewTextHandler(w)
+		})
 	})
 
 	log := slogt.New(t, f)


### PR DESCRIPTION
There was a breaking API change in how to instantiate a new text or JSON handler, so update slogt to use the new API.

I'm not sure which tagged version of golang.org/x/exp introduced the breaking change; I just updated to .../exp@latest.