### PR TITLE
v2: adopt Go 1.25 testing.TB.Output(); remove Bridge workaround

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,16 +13,19 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.25.x", "stable"]
     steps:
     - uses: actions/checkout@v6
 
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: "1.21.0"
+        go-version: ${{ matrix.go-version }}
 
     - name: Build
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test -race -v ./...

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # slogt
 
 `slogt` is a bridge between Go stdlib [`testing`](https://pkg.go.dev/testing) pkg
-and [`log/slog`](https://pkg.go.dev/golang.org/log/slog).
+and [`log/slog`](https://pkg.go.dev/log/slog).
 
 
 The problem: when tests execute, your `slog` output goes directly to `stdout`,
@@ -19,7 +19,7 @@ Produces:
 
 ```text
 === RUN   TestSlog_Ugly
-    slogt_test.go:22: I am indented correctly
+    slogt_test.go:21: I am indented correctly
 time=2023-04-01T11:29:27.236-06:00 level=INFO msg="But I am not"
 ```
 
@@ -39,8 +39,8 @@ Produces:
 
 ```text
 === RUN   TestSlogt_Pretty
-    slogt_test.go:28: I am indented correctly
-    logger.go:230: time=2023-04-01T11:33:06.342-06:00 level=INFO msg="And so am I"
+    slogt_test.go:27: I am indented correctly
+    time=2026-05-23T10:00:00.000-06:00 level=INFO msg="And so am I"
 ```
 
 
@@ -49,7 +49,7 @@ Produces:
 Run `go get` as per procedure:
 
 ```shell
-go get -u github.com/neilotoole/slogt
+go get -u github.com/neilotoole/slogt/v2
 ```
 
 Then, use `slogt.New` to get a `*slog.Logger` that you can
@@ -66,7 +66,7 @@ Produces:
 
 ```text
 === RUN   TestText
-    logger.go:230: time=2023-04-01T11:14:53.073-06:00 level=INFO msg="hello world"
+    time=2026-05-23T10:00:00.000-06:00 level=INFO msg="hello world"
 ```
 
 In practice, you would pass the `*slog.Logger` returned from `slogt.New` to
@@ -84,8 +84,8 @@ func TestApp(t *testing.T) {
 }
 ```
 
-If the `app.DepositMoney` method logs anything, its output will be piped
-to `t.Log` as desired. 
+If the `app.DepositMoney` method logs anything, its output is routed to
+`t.Output()` and correlated with the running test.
 
 ### Options
 
@@ -103,21 +103,21 @@ Produces:
 
 ```text
 === RUN   TestJSON
-    logger.go:230: {"time":"2023-04-01T11:14:12.164085-06:00","level":"INFO","msg":"hello world"}
+    {"time":"2026-05-23T10:00:00.000-06:00","level":"INFO","msg":"hello world"}
 ```
 
 To switch the default handler:
 
 ```go
 func init() {
-    slogt.DefaultHandler = slogt.JSON	
+    slogt.SetDefault(slogt.JSON())
 }
 ```
 
 You can exercise full control over the handler using `slogt.Factory()`.
 
 ```go
-func TestSomething(T *testing.T) {
+func TestSomething(t *testing.T) {
     // This factory returns a slog.Handler using slog.LevelError.
     f := slogt.Factory(func(w io.Writer) slog.Handler {
        opts := &slog.HandlerOptions{
@@ -130,63 +130,10 @@ func TestSomething(T *testing.T) {
 }
 ```
 
-## Deficiency
+### Showing the caller
 
-> [!NOTE]
-> **Update (Go 1.25):** This deficiency directly motivated
-> [golang/go#59928](https://github.com/golang/go/issues/59928), which was accepted
-> and shipped in Go 1.25 as [`testing.TB.Output()`](https://pkg.go.dev/testing#T.Output).
-> `Output` returns an `io.Writer` that writes to the test log _without_ prepending a
-> source location, so writing to `t.Output()` instead of `t.Log()` avoids the bogus
-> callsite entirely. Combined with `AddSource: true` on the handler, the _correct_
-> callsite is then reported as a `source=` attribute.
->
-> The original issue (by [@earthboundkid](https://github.com/earthboundkid)):
->
-> > In a test, you often want to mock out the logger. It would be nice to be able to
-> > call t.Slog() and get a log/slog logger that send output to t.Log() with the
-> > correct caller information.
-> >
-> > See https://github.com/neilotoole/slogt for an example of a third party library
-> > providing this functionality, but note that it cannot provide correct caller
-> > information:
-> >
-> > > Alas, given the available functionality on testing.T (i.e. the Helper method),
-> > > and how slog is implemented, there's no way to have the correct callsite printed.
-> >
-> > It seems like this needs to be done on the Go side to fix the callsite.
-
-Calling `t.Log()` prints the callsite as the first element
-of each log statement (`logger.go:230` in the example below).
-
-```text
-=== RUN   TestText
-    logger.go:230: time=2023-04-01T11:14:53.073-06:00 level=INFO msg="hello world"
-```
-
-But `logger.go:230` is actually in the internals of `slog` package.
-What we really want to see is the location of the caller of, say, `log.Info()`.
-
-Alas, given the available functionality
-on `testing.T` (i.e. the `Helper` method), and how `slog` is implemented,
-there's no way to have the correct callsite printed.
-
-There are a number of ways this could be fixed:
-
-1. The Go team could implement a `testing.NewLogger(t)` function that effectively
-   does what this package does, but it would have access to the `testing.T`'s
-   internal state, and so could manipulate the calldepth.
-2. The `testing.T` type could expose a `HelperN(depth int)` method that allows
-   logging libraries and the like to manipulate the calldepth further. This would
-   be generically useful even independent of this particular case.
-3. The `slog` package could test if the handler implements an interface with
-   method `Helper()`, and if so, invoke that method. This would need to be
-   implemented in several spots in `slog` codebase, and would introduce a little
-   overhead.
-
-Being that none of the above are available right now, we have to live
-with the incorrect callsite always being printed. If you also want to
-see the correct callsite alongside the incorrect one, you can do this:
+By default, log lines carry no callsite (writing through `t.Output()` adds none).
+If you want the real caller, enable `AddSource: true` on the handler:
 
 ```go
 func TestCaller(t *testing.T) {
@@ -203,11 +150,71 @@ func TestCaller(t *testing.T) {
 }
 ```
 
-Which produces (note the `source` attribute):
+Produces (note the correct `source` attribute — the actual call site, not slog's
+internals):
 
 ```text
 === RUN   TestCaller
-    logger.go:230: time=2023-04-01T11:21:49.896-06:00 level=INFO source=/Users/neilotoole/slogt/slogt_test.go:103 msg="Show me the real callsite"
+    time=2026-05-23T10:00:00.000-06:00 level=INFO source=.../slogt_test.go:118 msg="Show me the real callsite"
 ```
 
+## History
 
+`slogt` originally had a notable deficiency: every log line was prefixed with a
+**bogus callsite** pointing into `slog`'s internals (e.g. `logger.go:230`) rather
+than the real `log.Info()` call site. This was unavoidable — the only sink
+available was `t.Log(string)`, a function call rather than an `io.Writer`, so
+`slogt` had to buffer slog's output and forward it through `t.Log`, which then
+attributed each line to `slog`'s own internals (the frame that called `Handle`)
+rather than the real call site. `t.Helper()` could not mark enough frames to fix it.
+
+That limitation directly motivated the upstream Go proposal
+[golang/go#59928](https://github.com/golang/go/issues/59928), which was accepted
+and shipped in **Go 1.25** as
+[`testing.TB.Output()`](https://pkg.go.dev/testing#T.Output): an `io.Writer` that
+writes to the test log without prepending a source location. As of `v2.0.0`,
+slogt writes straight to `t.Output()`, so the bogus prefix is gone — and the real
+caller is available via `AddSource: true` (see [Showing the caller](#showing-the-caller)).
+
+> [!NOTE]
+> This deficiency is what motivated [golang/go#59928](https://github.com/golang/go/issues/59928).
+> The original issue (by [@earthboundkid](https://github.com/earthboundkid)):
+>
+> > In a test, you often want to mock out the logger. It would be nice to be able to
+> > call t.Slog() and get a log/slog logger that send output to t.Log() with the
+> > correct caller information.
+> >
+> > See https://github.com/neilotoole/slogt for an example of a third party library
+> > providing this functionality, but note that it cannot provide correct caller
+> > information:
+> >
+> > > Alas, given the available functionality on testing.T (i.e. the Helper method),
+> > > and how slog is implemented, there's no way to have the correct callsite printed.
+> >
+> > It seems like this needs to be done on the Go side to fix the callsite.
+
+## Changelog
+
+### v2.0.0 (2026-05-23)
+
+- **Breaking:** require Go 1.25 and route output through
+  [`testing.TB.Output()`](https://pkg.go.dev/testing#T.Output), eliminating the
+  bogus slog-internal callsite prefix (see [History](#history)).
+- **Breaking:** remove the exported `Bridge` type (an internal workaround that is
+  no longer needed). The module path is now `github.com/neilotoole/slogt/v2`.
+- **Breaking:** replace the mutable `Default` package var with the
+  concurrency-safe `SetDefault` function.
+- Drop the stale `golang.org/x/exp` dependency; test CI across Go 1.25.x and stable.
+
+### v1.1.0 (2023-08-12)
+
+- Require Go 1.21; switch from `golang.org/x/exp/slog` to the standard library
+  `log/slog`.
+
+### v1.0.1 (2023-05-31)
+
+- Update README examples for the newer `golang.org/x/exp/slog` API.
+
+### v1.0.0 (2023-04-03)
+
+- Initial release: bridge between `testing.T` and `golang.org/x/exp/slog`.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,3 @@
-module github.com/neilotoole/slogt
+module github.com/neilotoole/slogt/v2
 
-go 1.21
-
+go 1.25

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/slogt.go
+++ b/slogt.go
@@ -1,37 +1,59 @@
-// Package slogt implements a bridge between stdlib testing pkg and
-// the slog logging library. Use slogt.New(t) to get a *slog.Logger.
+// Package slogt bridges Go's stdlib testing package and the log/slog
+// logging library: slogt.New(t) returns a *slog.Logger whose output is
+// routed to t.Output(), so log lines are correlated with the running test.
 package slogt
 
 import (
-	"bytes"
-	"context"
 	"io"
 	"log/slog"
 	"sync"
 	"testing"
 )
 
-var _ slog.Handler = (*Bridge)(nil)
+var (
+	defaultMu     sync.RWMutex
+	defaultOption = Text()
+)
 
-// Default sets the default handler. This
-// can be changed by the client.
-var Default = Text()
+// SetDefault sets the Option that New applies when it is called without a
+// handler Option. The initial default is Text(). SetDefault is safe for
+// concurrent use; a nil opt resets the default to Text().
+func SetDefault(opt Option) {
+	if opt == nil {
+		opt = Text()
+	}
+	defaultMu.Lock()
+	defaultOption = opt
+	defaultMu.Unlock()
+}
+
+// getDefault returns the current default Option.
+func getDefault() Option {
+	defaultMu.RLock()
+	defer defaultMu.RUnlock()
+	return defaultOption
+}
 
 // Option is a functional option type that is used
 // with New to configure the logger's underlying handler.
-type Option func(b *Bridge)
+type Option func(c *config)
+
+// config holds the resolved handler constructor used by New.
+type config struct {
+	newHandler func(w io.Writer) slog.Handler
+}
 
 // Text specifies a text handler.
 //
 //	log := slogt.New(t, slogt.Text())
 func Text() Option {
-	return func(b *Bridge) {
-		hOpts := &slog.HandlerOptions{
-			AddSource: false,
-			Level:     slog.LevelDebug,
+	return func(c *config) {
+		c.newHandler = func(w io.Writer) slog.Handler {
+			return slog.NewTextHandler(w, &slog.HandlerOptions{
+				AddSource: false,
+				Level:     slog.LevelDebug,
+			})
 		}
-		// The opts may have already set the handler.
-		b.Handler = slog.NewTextHandler(b.buf, hOpts)
 	}
 }
 
@@ -39,98 +61,38 @@ func Text() Option {
 //
 //	log := slogt.New(t, slogt.JSON())
 func JSON() Option {
-	return func(b *Bridge) {
-		hOpts := &slog.HandlerOptions{
-			AddSource: false,
-			Level:     slog.LevelDebug,
+	return func(c *config) {
+		c.newHandler = func(w io.Writer) slog.Handler {
+			return slog.NewJSONHandler(w, &slog.HandlerOptions{
+				AddSource: false,
+				Level:     slog.LevelDebug,
+			})
 		}
-		// The opts may have already set the handler.
-		b.Handler = slog.NewJSONHandler(b.buf, hOpts)
 	}
 }
 
-// Factory is specifies a custom factory function for
+// Factory specifies a custom factory function for
 // creating the logger's underlying handler.
 func Factory(fn func(w io.Writer) slog.Handler) Option {
-	return func(b *Bridge) {
-		b.Handler = fn(b.buf)
+	return func(c *config) {
+		c.newHandler = fn
 	}
 }
 
-// New returns a new *slog.Logger whose logging methods
-// pipe output to t.Log.
+// New returns a new *slog.Logger whose output is routed to t.Output()
+// (added in Go 1.25). Output is correlated with the test like t.Log, but
+// carries no bogus callsite prefix. Set AddSource: true on the handler to
+// surface the real caller as a source= attribute.
 func New(t testing.TB, opts ...Option) *slog.Logger {
-	h := &Bridge{
-		t:   t,
-		buf: &bytes.Buffer{},
-		mu:  &sync.Mutex{},
-	}
-
+	c := &config{}
 	for _, opt := range opts {
-		opt(h)
+		opt(c)
 	}
 
-	if h.Handler == nil {
-		// No handler set yet, use the default handler.
-		Default(h)
+	if c.newHandler == nil {
+		// No handler set yet, use the default.
+		getDefault()(c)
 	}
 
-	return slog.New(h)
-}
-
-// Bridge is an implementation of slog.Handler that works
-// with the stdlib testing pkg.
-type Bridge struct {
-	slog.Handler
-	t   testing.TB
-	buf *bytes.Buffer
-	mu  *sync.Mutex
-}
-
-// Handle implements slog.Handler.
-func (b *Bridge) Handle(ctx context.Context, rec slog.Record) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	err := b.Handler.Handle(ctx, rec)
-	if err != nil {
-		return err
-	}
-
-	output, err := io.ReadAll(b.buf)
-	if err != nil {
-		return err
-	}
-
-	// The output comes back with a newline, which we need to
-	// trim before feeding to t.Log.
-	output = bytes.TrimSuffix(output, []byte("\n"))
-
-	// Append calldepth. But it won't be enough, and the internal slog
-	// callsite will be printed. See discussion in README.md.
-	b.t.Helper()
-
-	b.t.Log(string(output))
-
-	return nil
-}
-
-// WithAttrs implements slog.Handler.
-func (b *Bridge) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &Bridge{
-		t:       b.t,
-		buf:     b.buf,
-		mu:      b.mu,
-		Handler: b.Handler.WithAttrs(attrs),
-	}
-}
-
-// WithGroup implements slog.Handler.
-func (b *Bridge) WithGroup(name string) slog.Handler {
-	return &Bridge{
-		t:       b.t,
-		buf:     b.buf,
-		mu:      b.mu,
-		Handler: b.Handler.WithGroup(name),
-	}
+	return slog.New(c.newHandler(t.Output()))
 }

--- a/slogt_internal_test.go
+++ b/slogt_internal_test.go
@@ -1,0 +1,138 @@
+package slogt
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// newLog applies opt and returns a logger writing to buf. It exercises the
+// same handler-construction path as New, minus the testing.TB.Output() sink
+// (which cannot be faked because testing.TB has an unexported method).
+func newLog(buf io.Writer, opt Option) *slog.Logger {
+	c := &config{}
+	opt(c)
+	if c.newHandler == nil {
+		// Mirror New: fall back to the default when opt set no handler.
+		getDefault()(c)
+	}
+	return slog.New(c.newHandler(buf))
+}
+
+func TestText_noBogusCallsite(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, Text()).Info("hello world")
+
+	got := buf.String()
+	// t.Output() prepends no file:line, and Text() defaults to AddSource:false,
+	// so the line starts with the slog fields and carries no callsite at all.
+	if !strings.HasPrefix(got, "time=") {
+		t.Fatalf("text output should begin with time=, not a callsite prefix, got: %q", got)
+	}
+	if strings.Contains(got, "source=") {
+		t.Fatalf("Text() should not emit source=, got: %q", got)
+	}
+	if !strings.Contains(got, "level=INFO") || !strings.Contains(got, `msg="hello world"`) {
+		t.Fatalf("unexpected text output: %q", got)
+	}
+}
+
+func TestJSON_format(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, JSON()).Info("hello world")
+
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("json output is not valid JSON: %v; got: %q", err, buf.String())
+	}
+	if m["msg"] != "hello world" {
+		t.Fatalf(`expected msg="hello world", got: %q`, buf.String())
+	}
+}
+
+func TestFactory_levelFiltering(t *testing.T) {
+	var buf bytes.Buffer
+	log := newLog(&buf, Factory(func(w io.Writer) slog.Handler {
+		return slog.NewTextHandler(w, &slog.HandlerOptions{Level: slog.LevelError})
+	}))
+
+	log.Info("should be filtered out")
+	log.Error("should be printed")
+
+	got := buf.String()
+	if strings.Contains(got, "should be filtered out") {
+		t.Fatalf("info should be filtered at LevelError, got: %q", got)
+	}
+	if !strings.Contains(got, "should be printed") {
+		t.Fatalf("error should be printed, got: %q", got)
+	}
+}
+
+func TestAddSource_correctCallsite(t *testing.T) {
+	var buf bytes.Buffer
+	log := newLog(&buf, Factory(func(w io.Writer) slog.Handler {
+		return slog.NewTextHandler(w, &slog.HandlerOptions{AddSource: true})
+	}))
+
+	// Capture the file and line of the log.Info call below. runtime.Caller(0)
+	// is one line above log.Info, so we add 1 to get the actual callsite line.
+	_, file, line, _ := runtime.Caller(0)
+	log.Info("real callsite")
+
+	got := buf.String()
+	if !strings.Contains(got, "source=") {
+		t.Fatalf("AddSource output should contain source=, got: %q", got)
+	}
+	want := fmt.Sprintf("%s:%d", file, line+1)
+	if !strings.Contains(got, want) {
+		t.Fatalf("source should point at the caller %s, got: %q", want, got)
+	}
+}
+
+func TestWithAttrs_appearsInOutput(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, Text()).With("requestID", "abc-123").Info("handled")
+	if got := buf.String(); !strings.Contains(got, "requestID=abc-123") {
+		t.Fatalf("With() attrs missing from output: %q", got)
+	}
+}
+
+func TestText_debugLevelEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, Text()).Debug("debug me")
+	if got := buf.String(); !strings.Contains(got, "level=DEBUG") {
+		t.Fatalf("Text() should log at LevelDebug, got: %q", got)
+	}
+}
+
+// TestNew_defaultPath exercises New's real t.Output() sink and the no-option
+// default branch. The output can't be captured (testing.TB can't be faked),
+// so this asserts that construction and logging don't panic.
+func TestNew_defaultPath(t *testing.T) {
+	log := New(t) // no options -> getDefault() -> Text()
+	if log == nil {
+		t.Fatal("New returned nil")
+	}
+	log.Info("smoke", "key", "value")
+}
+
+// TestSetDefault_raceSafe hammers SetDefault and getDefault concurrently; it
+// is meaningful under `go test -race`, guarding the package default's access.
+func TestSetDefault_raceSafe(t *testing.T) {
+	t.Cleanup(func() { SetDefault(Text()) })
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Go(func() {
+			SetDefault(JSON())
+			_ = getDefault()
+		})
+	}
+	wg.Wait()
+}

--- a/slogt_test.go
+++ b/slogt_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/neilotoole/slogt"
+	"github.com/neilotoole/slogt/v2"
 )
 
 const (
@@ -32,14 +32,14 @@ func TestSlogt_Pretty(t *testing.T) {
 // ugly when using t.Parallel(), because
 // the slog.Logger output is not tied to the testing.T.
 func TestSlog_Ugly_Parallel(t *testing.T) {
-	for i := 0; i < iter; i++ {
+	for i := range iter {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
 			handler := slog.NewTextHandler(os.Stdout, nil)
 			log := slog.New(handler)
 
-			for j := 0; j < iter; j++ {
+			for j := range iter {
 				t.Log("YAY: this is indented as expected.")
 				log := log.With("count", j)
 				log.Info("BOO: This, alas, is not indented.")
@@ -53,12 +53,12 @@ func TestSlog_Ugly_Parallel(t *testing.T) {
 
 // TestSlogt_Pretty demonstrates use of slog with testing.T.
 func TestSlogt_Pretty_Parallel(t *testing.T) {
-	for i := 0; i < iter; i++ {
+	for i := range iter {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
 			log := slogt.New(t)
-			for j := 0; j < iter; j++ {
+			for j := range iter {
 				t.Log("testing.T: this is indented as expected.")
 
 				log.Debug("slogt: debug")
@@ -119,7 +119,9 @@ func TestCaller(t *testing.T) {
 }
 
 func TestDefaultHandler(t *testing.T) {
-	slogt.Default = slogt.JSON()
+	t.Cleanup(func() { slogt.SetDefault(slogt.Text()) })
+
+	slogt.SetDefault(slogt.JSON())
 	log := slogt.New(t)
 	log.Info("should show json")
 }


### PR DESCRIPTION
## Summary

Adopts Go 1.25's [`testing.TB.Output()`](https://pkg.go.dev/testing#T.Output) so slog output is routed to the test log **without** the bogus `logger.go:NNN` callsite prefix that slogt could never avoid. That deficiency is what motivated [golang/go#59928](https://github.com/golang/go/issues/59928) (which cites slogt); it's now resolved upstream, and slogt can finally do the thing it always wanted to.

- Route output through `t.Output()` and delete the `Bridge`/buffer/mutex workaround — slog now writes and locks itself.
- **Breaking:** remove the exported `Bridge` type. Module path is now `github.com/neilotoole/slogt/v2`; Go floor is `go 1.25`.
- Drop the stale `golang.org/x/exp` dependency (the code is pure stdlib `log/slog`).
- CI: test across Go `1.25.x` and `stable`.
- README: replace the old "Deficiency" section with **Showing the caller**, **History** (carrying the #59928 callout), and **Changelog**; fix two pre-existing doc bugs (the `log/slog` link and the `slogt.Default` snippet).
- New white-box tests verify there's no bogus prefix, that level filtering works, and that `AddSource: true` reports the correct caller `source=`.
- Modernize the parallel-demo test loops to range-over-int.

Prepares a `v2.0.0` release. No tag is created by this PR.

## Test Plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test -v ./...` (all pass)
- [x] `go test -race ./...` (no data race)
- [ ] CI green on Go `1.25.x` and `stable`