### PR TITLE
ci: coverage reporting (Codecov) + badges

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,15 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test -race -shuffle=on -v ./...
+      run: go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out -v ./...
+
+    - name: Upload coverage to Codecov
+      if: matrix.go-version == 'stable'
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.out
+        fail_ci_if_error: false
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # slogt
 
+[![Go](https://github.com/neilotoole/slogt/actions/workflows/go.yml/badge.svg)](https://github.com/neilotoole/slogt/actions/workflows/go.yml)
+[![codecov](https://codecov.io/gh/neilotoole/slogt/graph/badge.svg)](https://codecov.io/gh/neilotoole/slogt)
+[![Go Reference](https://pkg.go.dev/badge/github.com/neilotoole/slogt/v2.svg)](https://pkg.go.dev/github.com/neilotoole/slogt/v2)
+
 `slogt` is a bridge between Go stdlib [`testing`](https://pkg.go.dev/testing) pkg
 and [`log/slog`](https://pkg.go.dev/log/slog).
 


### PR DESCRIPTION
## Summary

Adds code-coverage reporting and repo badges.

- The `build` job now produces an atomic coverage profile: `go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out -v ./...`.
- A new step uploads it to Codecov on the **stable** Go leg only (one upload per run), via `codecov/codecov-action@v6`. It's **non-blocking** (`fail_ci_if_error: false`), so CI stays green even before the token is configured.
- README gains three badges: Go build status, Codecov coverage, and pkg.go.dev reference.

Coverage is currently **100% of statements** locally.

## One-time manual setup required (to light up the badge)

The Codecov upload needs a token:
1. Sign in at https://codecov.io with GitHub and add the `neilotoole/slogt` repo.
2. Copy its upload token and add it as a repo secret named `CODECOV_TOKEN` (Settings → Secrets and variables → Actions → New repository secret).

Until then, CI still passes (upload is non-blocking) and the badge shows "unknown". After the token is set and this lands on `master`, the next run uploads coverage and the badge populates.

## Test Plan
- [x] `go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out ./...` → 100% locally
- [x] `coverage.out` is gitignored (`*.out`)
- [ ] CI green on this PR (build matrix + lint + non-blocking Codecov upload)